### PR TITLE
update CA certificate to allow SSL use from some Python libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM alpine:3.4
 
-RUN apk add --no-cache python3 && \
+RUN apk add --update && \
+    apk add ca-certificates && \
+    update-ca-certificates && \
+    apk add --no-cache python3 && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade pip setuptools && \


### PR DESCRIPTION
I ran into an issue about SSL validity verification with this Docker images, the following comment did the job to make it works

(cf : guneysus commented on 24 Sep
https://github.com/tornadoweb/tornado/issues/1534#issuecomment-249389041 )