### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN echo "**** install Python ****" && \
     \
     echo "**** install pip ****" && \
     python3 -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
+    rm -rf /usr/lib/python*/ensurepip && \
     pip3 install --no-cache --upgrade pip setuptools wheel && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.10
 
+ENV PYTHONUNBUFFERED=1 \
+    LANG=C.UTF-8
+
 RUN echo "**** install Python ****" && \
     apk add --no-cache python3 && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \


### PR DESCRIPTION
- Enable `PYTHONUNBUFFERED` to force stdin, stdout and stderr to be totally unbuffered (eg. avoid delayed prints).
- Set `LANG` to use UTF-8 encoding rather than default ASCII.
- Always ignore nonexistent `ensurepip` folder when removing.